### PR TITLE
add LANG exports to fix click in pipenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Analyze and estimate Jukola Relay results
 
 ## Setup
 ```bash
+export LC_ALL=en_US.utf-8
+export LANG=en_US.utf-8
 pipenv sync
 ```
 


### PR DESCRIPTION
Adds LANG exports in setup to help installing. Click fails if LC_ALL and LANG not set by user previously.

`Traceback (most recent call last):
  File "/Users/tjpajala/anaconda3/envs/jukola/bin/pipenv", line 10, in <module>
    sys.exit(cli())
  File "/Users/tjpajala/anaconda3/envs/jukola/lib/python3.6/site-packages/pipenv/vendor/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/Users/tjpajala/anaconda3/envs/jukola/lib/python3.6/site-packages/pipenv/vendor/click/core.py", line 696, in main
    _verify_python3_env()
  File "/Users/tjpajala/anaconda3/envs/jukola/lib/python3.6/site-packages/pipenv/vendor/click/_unicodefun.py", line 124, in _verify_python3_env
    ' mitigation steps.' + extra
RuntimeError: Click will abort further execution because Python 3 was configured to use ASCII as encoding for the environment. Consult https://click.palletsprojects.com/en/7.x/python3/ for mitigation steps.
`